### PR TITLE
connecting-pageのUIを実装

### DIFF
--- a/vanx-app/app/connection/page.tsx
+++ b/vanx-app/app/connection/page.tsx
@@ -1,3 +1,50 @@
+"use client";
+
+import { useState } from "react";
+import { Logo, Modal } from "@/components/shared";
+import { LoadingIcon, LargeCheckIcon, FailureIcon } from "@/components/shared/icons";
+
+type isConnecting = "connecting" | "connected" | "failed";
+
 export default function Connection() {
-  return <>{/* 接続ページ */}</>;
+  const [connectionState, setConnectionState] = useState<isConnecting>("failed");
+
+  return (
+    <main>
+      <div className="flex justify-center items-start w-screen h-screen mt-20">
+        <Logo />
+      </div>
+      <Modal
+        size="large"
+        openModal={true} // 常に表示
+        onClose={() => {}} // 閉じる操作を無効化
+      >
+        {connectionState === "connecting" ? (
+          <div className="flex flex-col items-center gap-4">
+            <LoadingIcon className="animate-spin"/>
+            <p className="text-text text-normal">接続中...</p>
+          </div>
+        ) : connectionState === "connected" ? (
+          <div className="flex flex-col items-center gap-4">
+            <LargeCheckIcon />
+            <div className="text-normal text-text text-center">
+              <p>接続に成功しました！</p>
+              <p>ゲームをお楽しみください！</p>
+            </div>
+          </div>
+        ) : (
+          <div className="flex flex-col items-center gap-4">
+            <FailureIcon />
+            <p>接続に失敗しました</p>
+            <button
+              className="flex justify-center items-center w-50 h-11 bg-accent text-white rounded-full mt-7"
+              onClick={() => setConnectionState("connecting")} // connectionStateを"connecting"に変更
+            >
+              もう一度接続
+            </button>
+          </div>
+        )}
+      </Modal>
+    </main>
+  );
 }


### PR DESCRIPTION
**【やったこと】**

- コンテンツを掲載するModalを常に表示
- コンテンツの切り替えは`setConnectionState`を使って手動で行います
- `connecting` : 接続中...
   `connected` : 接続完了
   `failed`          : 接続失敗
   に分けてコンテンツを作成

---

こんな感じ

<img width="240" height="480" alt="Screenshot_20250918-165148" src="https://github.com/user-attachments/assets/cf14e11a-ebe6-4722-85e2-b0bccbbbae47" />

<img width="240" height="480" alt="Screenshot_20250918-165834" src="https://github.com/user-attachments/assets/44467f83-ba77-4bbe-ae27-509d13a3099d" />

<img width="240" height="480" alt="Screenshot_20250918-165602" src="https://github.com/user-attachments/assets/1d9f14a3-9b1f-4cde-8e0c-6fcb74cf28ac" />
