### PR TITLE
Create: ProfilePostIndex API

### DIFF
--- a/vanx-app/api/post/postIndex.ts
+++ b/vanx-app/api/post/postIndex.ts
@@ -6,7 +6,9 @@ export type PostIndexResponse =
     success: true;
     message: string;
     data: {
-      posts: Post[];
+      posts: {
+        data: Post[];
+      }
     }
   }
   | {

--- a/vanx-app/api/post/postIndex.ts
+++ b/vanx-app/api/post/postIndex.ts
@@ -1,4 +1,5 @@
 import axios from "axios";
+import humps from "humps";
 import { Post } from "./types";
 
 export type PostIndexResponse = 
@@ -21,6 +22,7 @@ export async function PostIndex(): Promise<PostIndexResponse> {
 
   try {
     const res = await axios.get<PostIndexResponse>(apiUrl);
+    res.data = humps.camelizeKeys(res.data) as PostIndexResponse;
     return res.data;
   } catch (err: any) {
     return {

--- a/vanx-app/api/post/postIndex.ts
+++ b/vanx-app/api/post/postIndex.ts
@@ -1,24 +1,12 @@
 import axios from "axios";
-import { User } from "../auth/types";
-import { Reaction, PostFiles } from "./types";
+import { Post } from "./types";
 
 export type PostIndexResponse = 
   | {
     success: true;
     message: string;
     data: {
-      posts: [
-        {
-          id: number;
-          userId: number;
-          postContent: string;
-          createdAt: string;
-          updatedAt: string;
-          user: User;
-          postFiles: PostFiles[];
-          postReactions: Reaction[];
-        }
-      ]
+      posts: Post[];
     }
   }
   | {
@@ -26,16 +14,16 @@ export type PostIndexResponse =
     message: string;
   }
 
-export async function PostIndex() {
+export async function PostIndex(): Promise<PostIndexResponse> {
   const apiUrl = `${process.env.NEXT_PUBLIC_API_URL}/api/post/posts`;
 
-  return axios
-    .get<PostIndexResponse>(apiUrl)
-    .then((res) => res.data)
-    .catch((err) => {
-      return {
-        success: false as const,
-        message: err.response?.data?.message || "投稿一覧の取得に失敗しました",
-      }
-    });
-};
+  try {
+    const res = await axios.get<PostIndexResponse>(apiUrl);
+    return res.data;
+  } catch (err: any) {
+    return {
+      success: false,
+      message: err.response?.data?.message || "投稿一覧の取得に失敗しました",
+    };
+  }
+}

--- a/vanx-app/api/post/postStore.ts
+++ b/vanx-app/api/post/postStore.ts
@@ -1,24 +1,13 @@
 import axios from "axios";
 import Cookies from "js-cookie";
-
-import { User } from "../auth/types";
-import { Reaction, PreviewFile } from "./types";
+import { Post } from "./types";
 
 export type postStoreResponse = {
   success: boolean;
   message: string;
   data?: {
-    post: {
-      id: number;
-      userId: number;
-      postContent: string;
-      created_at: string;
-      updated_at: string;
-      user: User;
-      files: PreviewFile[];
-      reactions: Reaction[];
-    }
-  } 
+    post: Post[];
+  }
 }
 
 export async function postStore(formData: FormData) {

--- a/vanx-app/api/post/types.ts
+++ b/vanx-app/api/post/types.ts
@@ -1,7 +1,9 @@
+import { User } from "../auth";
+
 export type Post = {
   id: number;
   userId: number;
-  userName: string;
+  user: User;
   imageSrc: string;
   postContent: string;
   postfile?: PostFile[];

--- a/vanx-app/api/post/types.ts
+++ b/vanx-app/api/post/types.ts
@@ -5,7 +5,15 @@ export type Post = {
   imageSrc: string;
   contents: string;
   files?: PreviewFile[];
-  postReactions: Reaction[];
+  postReactions: PostReaction[];
+};
+
+export type PostReaction = {
+  id: number;
+  userId: number;
+  postId: number;
+  reactionId: number;
+  reaction: Reaction;
 };
 
 export type Reaction = {

--- a/vanx-app/api/post/types.ts
+++ b/vanx-app/api/post/types.ts
@@ -3,8 +3,8 @@ export type Post = {
   userId: number;
   userName: string;
   imageSrc: string;
-  contents: string;
-  files?: PreviewFile[];
+  postContent: string;
+  files?: PostFile[];
   postReactions: PostReaction[];
 };
 
@@ -30,7 +30,7 @@ export type PreviewFile = {
   name?: string;
 };
 
-export type PostFiles = {
+export type PostFile = {
   id: number;
   postId: number;
   postFilePath: string;

--- a/vanx-app/api/post/types.ts
+++ b/vanx-app/api/post/types.ts
@@ -4,7 +4,7 @@ export type Post = {
   userName: string;
   imageSrc: string;
   postContent: string;
-  files?: PostFile[];
+  postfile?: PostFile[];
   postReactions: PostReaction[];
 };
 
@@ -35,6 +35,5 @@ export type PostFile = {
   postId: number;
   postFilePath: string;
   postFileType: string;
-  createdAt: string;
-  updatedAt: string;
+  postFileUrl: string;
 }

--- a/vanx-app/api/profile/index.ts
+++ b/vanx-app/api/profile/index.ts
@@ -1,0 +1,2 @@
+export * from "./profilePostIndex";
+export * from "./profileIndex";

--- a/vanx-app/api/profile/profilePostIndex.ts
+++ b/vanx-app/api/profile/profilePostIndex.ts
@@ -1,5 +1,6 @@
 import axios from "axios";
 import Cookies from "js-cookie";
+import humps from "humps";
 import { User } from "../auth";
 import { Post } from "../post";
 
@@ -30,6 +31,7 @@ export async function ProfilePostIndex({ userId }: { userId: number | undefined 
       }
     })
     .then(res => {
+      res.data = humps.camelizeKeys(res.data) as ProfilePostIndexResponse;
       return res.data;
     })
     .catch(err => {

--- a/vanx-app/api/profile/profilePostIndex.ts
+++ b/vanx-app/api/profile/profilePostIndex.ts
@@ -1,23 +1,23 @@
 import axios from "axios";
 import Cookies from "js-cookie";
 import humps from "humps";
-import { User } from "../auth";
 import { Post } from "../post";
+import { User } from "../auth";
 
 export type ProfilePostIndexResponse = 
   | {
-    success: true;
-    message: "取得に成功しました";
-    data: {
-      user: User;
-      posts: Post[];
+      success: true;
+      message: "取得に成功しました";
+      data: {
+        posts: Post[];
+        user: User;
+      };
     }
-  }
   | {
-    success: false;
-    message: "取得に失敗しました";
-    errors: { err: string }[];
-  }
+      success: false;
+      message: "取得に失敗しました";
+      errors: { err: string }[];
+    };
 
 export async function ProfilePostIndex({ userId }: { userId: number | undefined }) {
   const apiUrl = `${process.env.NEXT_PUBLIC_API_URL}/api/account/profile/${userId}`;

--- a/vanx-app/api/profile/profilePostIndex.ts
+++ b/vanx-app/api/profile/profilePostIndex.ts
@@ -1,0 +1,44 @@
+import axios from "axios";
+import Cookies from "js-cookie";
+import { User } from "../auth";
+import { Post } from "../post";
+
+export type ProfilePostIndexResponse = 
+  | {
+    success: true;
+    message: "取得に成功しました";
+    data: {
+      user: User;
+      posts: Post[];
+    }
+  }
+  | {
+    success: false;
+    message: "取得に失敗しました";
+    errors: { err: string }[];
+  }
+
+export async function ProfilePostIndex({ userId }: { userId: string }) {
+  const apiUrl = `${process.env.NEXT_PUBLIC_API_URL}/api/account/profile/${userId}`;
+  const authToken = Cookies.get("authToken");
+
+  return axios
+    .get<ProfilePostIndexResponse>(apiUrl, {
+      headers: {
+        Authorization: `Bearer ${authToken}`,
+        Accept: "application/json"
+      }
+    })
+    .then(res => {
+      return res.data;
+    })
+    .catch(err => {
+      console.error("ERROR: ", err);
+
+      return {
+        success: false,
+        message: "取得に失敗しました",
+        errors: [{ err: err.message || "取得に失敗しました" }]
+      };
+    })
+}

--- a/vanx-app/api/profile/profilePostIndex.ts
+++ b/vanx-app/api/profile/profilePostIndex.ts
@@ -18,7 +18,7 @@ export type ProfilePostIndexResponse =
     errors: { err: string }[];
   }
 
-export async function ProfilePostIndex({ userId }: { userId: string }) {
+export async function ProfilePostIndex({ userId }: { userId: number | undefined }) {
   const apiUrl = `${process.env.NEXT_PUBLIC_API_URL}/api/account/profile/${userId}`;
   const authToken = Cookies.get("authToken");
 

--- a/vanx-app/app/page.tsx
+++ b/vanx-app/app/page.tsx
@@ -8,15 +8,12 @@ import { usePostDelete } from "@/hooks/usePostDelete";
 
 export default function Home() {
   const { user } = useUser();
-  const { posts, setPosts, loading, error } = usePosts();
+  const { posts, setPosts } = usePosts();
   const { handlePostDelete } = usePostDelete();
 
   const onPostDelete = async (postId: number) => {
     await handlePostDelete(postId, setPosts);
   };
-
-  if (loading) return <div>読み込み中...</div>;
-  if (error) return <div>エラー: {error}</div>;
 
   return (
     <>

--- a/vanx-app/app/profile/[user_id]/edit/page.tsx
+++ b/vanx-app/app/profile/[user_id]/edit/page.tsx
@@ -5,7 +5,7 @@ export default function ProfileEdit() {
   return (
     <main>
       <ReturnButton />
-      <form className="flex flex-col justify-center mt-12">
+      <form className="flex flex-col justify-center mt-28">
         <div className="flex flex-col items-center gap-8">
           <Image
             className="border-[0.5px] border-text-gray rounded-full"

--- a/vanx-app/app/profile/[user_id]/page.tsx
+++ b/vanx-app/app/profile/[user_id]/page.tsx
@@ -9,11 +9,13 @@ import { useUser } from "@/contexts/UserContext";
 import { usePostDelete } from "@/hooks/usePostDelete";
 import { ProfilePostIndex } from "@/api/profile/profilePostIndex";
 import { Post } from "@/api/post";
+import { User } from "@/api/auth";
 
 export default function Profile() {
   const { user } = useUser();
   const { user_id: userId } = useParams();
   const [posts, setPosts] = useState<Post[]>([]);
+  const [userData, setUserData] = useState<User | null>(null);
   const { handlePostDelete } = usePostDelete();
 
   const onPostDelete = async (postId: number) => {
@@ -25,10 +27,15 @@ export default function Profile() {
       if (userId) {
         try {
           const response = await ProfilePostIndex({ userId: Number(userId) });
-
+          
           if (response.success && "data" in response) {
-            const data = response.data as { posts: Post[] };
-            setPosts(data.posts);
+            const data = response.data as { posts: Post[]; user: User };
+            const responseUser = data.user;
+            const postsData = data.posts;
+            const postsArray = Array.isArray(postsData) ? postsData : [];
+
+            setPosts(postsArray);
+            setUserData(responseUser);
           }
         } catch (error) {
           console.error("ERROR", error);
@@ -39,8 +46,6 @@ export default function Profile() {
     fetchPosts();
   }, [userId]);
 
-  console.log(posts);
-
   return (
     <main>
       <div className="fixed top-0 left-0 w-full">
@@ -49,7 +54,7 @@ export default function Profile() {
       </div>
 
       <div className="mt-56">
-        <PostList posts={posts} onPostDelete={onPostDelete} />
+        <PostList posts={posts} user={userData} onPostDelete={onPostDelete} />
       </div>
     </main>
   );

--- a/vanx-app/app/profile/[user_id]/page.tsx
+++ b/vanx-app/app/profile/[user_id]/page.tsx
@@ -3,10 +3,12 @@
 import { ReturnButton } from "@/components/shared";
 import { ProfileHead } from "@/components/features/profile/ProfileHead";
 import { PostList } from "@/components/features/post";
+import { useUser } from "@/contexts/UserContext";
 import { usePosts } from "@/hooks/usePosts";
 import { usePostDelete } from "@/hooks/usePostDelete";
 
 export default function Profile() {
+  const { user } = useUser();
   const { posts, setPosts, loading, error } = usePosts();
   const { handlePostDelete } = usePostDelete();
 
@@ -18,7 +20,7 @@ export default function Profile() {
     <main>
       <div className="fixed top-0 left-0 w-full">
         <ReturnButton />
-        <ProfileHead />
+        {user && <ProfileHead user={user} />}
       </div>
 
       <div className="mt-56">

--- a/vanx-app/app/profile/[user_id]/page.tsx
+++ b/vanx-app/app/profile/[user_id]/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { useParams } from "next/navigation";
 import { ReturnButton } from "@/components/shared";
 import { ProfileHead } from "@/components/features/profile/";
 import { PostList } from "@/components/features/post";
@@ -11,6 +12,7 @@ import { Post } from "@/api/post";
 
 export default function Profile() {
   const { user } = useUser();
+  const { user_id: userId } = useParams();
   const [posts, setPosts] = useState<Post[]>([]);
   const { handlePostDelete } = usePostDelete();
 
@@ -20,20 +22,24 @@ export default function Profile() {
 
   useEffect(() => {
     const fetchPosts = async () => {
-      try {
-        const response = await ProfilePostIndex({ userId: user?.id });
+      if (userId) {
+        try {
+          const response = await ProfilePostIndex({ userId: Number(userId) });
 
-        if (response.success && "data" in response) {
-          const data = response.data as { posts: Post[] };
-          setPosts(data.posts);
+          if (response.success && "data" in response) {
+            const data = response.data as { posts: Post[] };
+            setPosts(data.posts);
+          }
+        } catch (error) {
+          console.error("ERROR", error);
         }
-      } catch (error) {
-        console.error("ERROR", error);
       }
     };
 
     fetchPosts();
-  }, [user?.id]);
+  }, [userId]);
+
+  console.log(posts);
 
   return (
     <main>

--- a/vanx-app/app/profile/[user_id]/page.tsx
+++ b/vanx-app/app/profile/[user_id]/page.tsx
@@ -1,20 +1,39 @@
 "use client";
 
+import { useState, useEffect } from "react";
 import { ReturnButton } from "@/components/shared";
-import { ProfileHead } from "@/components/features/profile/ProfileHead";
+import { ProfileHead } from "@/components/features/profile/";
 import { PostList } from "@/components/features/post";
 import { useUser } from "@/contexts/UserContext";
-import { usePosts } from "@/hooks/usePosts";
 import { usePostDelete } from "@/hooks/usePostDelete";
+import { ProfilePostIndex } from "@/api/profile/profilePostIndex";
+import { Post } from "@/api/post";
 
 export default function Profile() {
   const { user } = useUser();
-  const { posts, setPosts, loading, error } = usePosts();
+  const [posts, setPosts] = useState<Post[]>([]);
   const { handlePostDelete } = usePostDelete();
 
   const onPostDelete = async (postId: number) => {
     await handlePostDelete(postId, setPosts);
   };
+
+  useEffect(() => {
+    const fetchPosts = async () => {
+      try {
+        const response = await ProfilePostIndex({ userId: user?.id });
+
+        if (response.success && "data" in response) {
+          const data = response.data as { posts: Post[] };
+          setPosts(data.posts);
+        }
+      } catch (error) {
+        console.error("ERROR", error);
+      }
+    };
+
+    fetchPosts();
+  }, [user?.id]);
 
   return (
     <main>
@@ -24,13 +43,7 @@ export default function Profile() {
       </div>
 
       <div className="mt-56">
-        {loading ? (
-          <div>読み込み中...</div>
-        ) : error ? (
-          <div>エラー: {error}</div>
-        ) : (
-          <PostList posts={posts} onPostDelete={onPostDelete} />
-        )}
+        <PostList posts={posts} onPostDelete={onPostDelete} />
       </div>
     </main>
   );

--- a/vanx-app/components/features/post/PostItem.tsx
+++ b/vanx-app/components/features/post/PostItem.tsx
@@ -3,19 +3,24 @@ import Link from "next/link";
 
 import { ReactionAddButton } from "./ReactionAddButton";
 import { Post } from "@/api/post/types";
+import { User } from "@/api/auth";
 import { DeleteIcon } from "@/components/shared/icons";
 
 type PostItemProps = {
   post: Post;
+  user?: User | null;
   onDelete: () => void;
   onClick: () => void;
 };
 
 export function PostItem({ 
   post, 
+  user,
   onDelete, 
   onClick 
 }: PostItemProps) {
+  const userName = user && user.name;
+
   return (
     <div className="flex flex-col gap-2 w-full min-w-screen border-b-[0.5px] border-b-text-gray py-4 px-6">
       <div className="flex gap-6">
@@ -38,7 +43,7 @@ export function PostItem({
         </Link>
 
         <div className="flex items-center gap-2">
-          <h2 className="text-bold">{post.user.name}</h2>
+          <h2 className="text-bold">{userName}</h2>
         </div>
 
         <div className="justify-self-end ml-auto">

--- a/vanx-app/components/features/post/PostItem.tsx
+++ b/vanx-app/components/features/post/PostItem.tsx
@@ -38,7 +38,7 @@ export function PostItem({
         </Link>
 
         <div className="flex items-center gap-2">
-          <h2 className="text-bold">{post.userName}</h2>
+          <h2 className="text-bold">{post.user.name}</h2>
         </div>
 
         <div className="justify-self-end ml-auto">
@@ -60,7 +60,12 @@ export function PostItem({
                   alt={`post-image-${file.id}`} 
                   width={300} 
                   height={200} 
-                  className="object-cover rounded-md"
+                  className={`
+                    ${file.postFileUrl.slice(-3) === "png" // png画像の時にborderをつけてみてるけど正直微妙
+                      && "border-[0.5px] border-text-gray"
+                    }
+                    object-cover rounded-md
+                  `}
                   unoptimized
                 />
               </div>

--- a/vanx-app/components/features/post/PostItem.tsx
+++ b/vanx-app/components/features/post/PostItem.tsx
@@ -61,8 +61,8 @@ export function PostItem({
                   width={300} 
                   height={200} 
                   className={`
-                    ${file.postFileUrl.slice(-3) === "png" // png画像の時にborderをつけてみてるけど正直微妙
-                      && "border-[0.5px] border-text-gray"
+                    ${file.postFileUrl.slice(-3) === "png"  // postFileTypeで判別できたら良いのになあ
+                      && "border-[0.5px] border-text-gray"  // png画像の時にborderをつけてみてるけど正直微妙
                     }
                     object-cover rounded-md
                   `}

--- a/vanx-app/components/features/post/PostItem.tsx
+++ b/vanx-app/components/features/post/PostItem.tsx
@@ -43,15 +43,15 @@ export function PostItem({ post, onDelete, onClick }: PostItemProps) {
         </div>
       </div>
 
-      <div>{post.contents}</div>
+      <div>{post.postContent}</div>
 
       <div>
         {post.files && post.files.length > 0 ? (
           post.files.map((file, index) => (
-            file.url ? (
+            file.postFilePath ? (
               <div key={file.id || index} className="my-2">
                 <Image 
-                  src={file.url} 
+                  src={file.postFilePath} 
                   alt={`post-image-${index}`} 
                   width={300} 
                   height={200} 
@@ -66,7 +66,7 @@ export function PostItem({ post, onDelete, onClick }: PostItemProps) {
 
       <div className="flex justify-end">
         <ReactionAddButton
-          postReactions={post.postReactions}
+          postReactions={post.postReactions || []}
           onClick={onClick}
         />
       </div>

--- a/vanx-app/components/features/post/PostItem.tsx
+++ b/vanx-app/components/features/post/PostItem.tsx
@@ -11,7 +11,11 @@ type PostItemProps = {
   onClick: () => void;
 };
 
-export function PostItem({ post, onDelete, onClick }: PostItemProps) {
+export function PostItem({ 
+  post, 
+  onDelete, 
+  onClick 
+}: PostItemProps) {
   return (
     <div className="flex flex-col gap-2 w-full min-w-screen border-b-[0.5px] border-b-text-gray py-4 px-6">
       <div className="flex gap-6">
@@ -28,7 +32,8 @@ export function PostItem({ post, onDelete, onClick }: PostItemProps) {
               src="/icons/default-user-icon.svg" 
               alt="user-icon" 
               width={50} 
-              height={50} />
+              height={50} 
+            />
           )}
         </Link>
 
@@ -46,13 +51,13 @@ export function PostItem({ post, onDelete, onClick }: PostItemProps) {
       <div>{post.postContent}</div>
 
       <div>
-        {post.files && post.files.length > 0 ? (
-          post.files.map((file, index) => (
-            file.postFilePath ? (
-              <div key={file.id || index} className="my-2">
+        {post.postfile && post.postfile.length > 0 ? (
+          post.postfile.map((file) => (
+            file.postFileUrl ? (
+              <div key={file.id} className="my-2">
                 <Image 
-                  src={file.postFilePath} 
-                  alt={`post-image-${index}`} 
+                  src={file.postFileUrl} 
+                  alt={`post-image-${file.id}`} 
                   width={300} 
                   height={200} 
                   className="object-cover rounded-md"

--- a/vanx-app/components/features/post/PostItem.tsx
+++ b/vanx-app/components/features/post/PostItem.tsx
@@ -19,7 +19,7 @@ export function PostItem({
   onDelete, 
   onClick 
 }: PostItemProps) {
-  const userName = user && user.name;
+  const userName = user ? user.name : post.user.name;
 
   return (
     <div className="flex flex-col gap-2 w-full min-w-screen border-b-[0.5px] border-b-text-gray py-4 px-6">

--- a/vanx-app/components/features/post/PostList.tsx
+++ b/vanx-app/components/features/post/PostList.tsx
@@ -49,7 +49,7 @@ export function PostList({ posts, onPostDelete }: PostListProps) {
         {posts.map((post) => {
           const normalizedPost = {
             ...post,
-            contents: post.contents ?? "",
+            contents: post.postContent ?? "",
           };
           
           return (

--- a/vanx-app/components/features/post/PostList.tsx
+++ b/vanx-app/components/features/post/PostList.tsx
@@ -43,8 +43,6 @@ export function PostList({ posts, onPostDelete }: PostListProps) {
     }
   };
 
-  console.log(posts);
-
   return (
     <>
       <ul>

--- a/vanx-app/components/features/post/PostList.tsx
+++ b/vanx-app/components/features/post/PostList.tsx
@@ -43,6 +43,8 @@ export function PostList({ posts, onPostDelete }: PostListProps) {
     }
   };
 
+  console.log(posts);
+
   return (
     <>
       <ul>

--- a/vanx-app/components/features/post/PostList.tsx
+++ b/vanx-app/components/features/post/PostList.tsx
@@ -6,13 +6,15 @@ import { PostDeleteModal } from "./PostDeleteModal";
 import { ReactionBottomSheet } from "./ReactionBottomSheet";
 import { Modal } from "@/components/shared";
 import { Post } from "@/api/post/types";
+import { User } from "@/api/auth/types";
 
 type PostListProps = {
   posts: Post[];
+  user?: User | null;
   onPostDelete: (postId: number) => Promise<void>;
 };
 
-export function PostList({ posts, onPostDelete }: PostListProps) {
+export function PostList({ posts, user, onPostDelete }: PostListProps) {
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const [isBottomSheetOpen, setIsBottomSheetOpen] = useState(false);
   const [isBottomSheetVisible, setIsBottomSheetVisible] = useState(false);
@@ -56,6 +58,7 @@ export function PostList({ posts, onPostDelete }: PostListProps) {
             <li key={post.id}>
               <PostItem
                 post={normalizedPost}
+                user={user}
                 onDelete={() => {
                   setCurrentPostId(post.id);
                   setIsDeleteModalOpen(true);

--- a/vanx-app/components/features/post/ReactionAddButton.tsx
+++ b/vanx-app/components/features/post/ReactionAddButton.tsx
@@ -1,8 +1,8 @@
 import Image from "next/image";
-import { Reaction } from "@/api/post/types";
+import { PostReaction } from "@/api/post/types";
 
 type ReactionAddButtonProps = {
-  postReactions: Reaction[];
+  postReactions: PostReaction[];
   onClick: () => void;
 };
 
@@ -33,8 +33,8 @@ export function ReactionAddButton({
         >
           <Image
             className="w-5 h-5"
-            src={reaction.reactionImageSrc}
-            alt={reaction.reactionName}
+            src={reaction.reaction.reactionImageSrc}
+            alt={reaction.reaction.reactionName}
             width={24}
             height={24}
           />

--- a/vanx-app/components/features/profile/ProfileHead.tsx
+++ b/vanx-app/components/features/profile/ProfileHead.tsx
@@ -2,13 +2,14 @@
 
 import Image from "next/image";
 import Link from "next/link";
+import { User } from "@/api/auth";
 import { EditIcon, LessThanIcon } from "@/components/shared/icons";
 
-export function ProfileHead() {
+export function ProfileHead({ user }: { user: User }) {
   return (
     <div className="pt-22 pb-4 px-6 bg-accent-light flex flex-col gap-8 shadow-bottom">
       <div className="flex justify-between">
-        <div className="flex gap-6">
+        <div className="flex gap-6 justify-center">
           <div className="size-12">
             <Image
               src="/icons/default-user-icon.svg"
@@ -18,17 +19,14 @@ export function ProfileHead() {
               className="rounded-full"
             />
           </div>
-          <div className="font-sans ">
-            <p className="text-small not-italic font-normal text-text-gray">
-              junpeichan@0310
-            </p>
-            <p className=" text-normal font-bold">じゅんぺいちゃん</p>
+          <div className="flex items-center text-normal font-bold">
+            {user.name}
           </div>
         </div>
 
         <div>
           <Link
-            href="/edit"
+            href={`/profile/${user.id}/edit`}
             className="flex items-center text-text-gray bg-gray rounded-full py-2 px-4  gap-2"
           >
             <p>編集</p>
@@ -42,7 +40,7 @@ export function ProfileHead() {
           href="/rankings"
           className="p-2 flex items-center gap-2 bg-accent text-accent-light rounded"
         >
-          <p>ランキングを見る</p>
+          ランキングを見る
           <LessThanIcon />
         </Link>
       </div>

--- a/vanx-app/components/shared/FooterNavItem.tsx
+++ b/vanx-app/components/shared/FooterNavItem.tsx
@@ -27,7 +27,7 @@ export function FooterNavItem({ userId }: { userId: number | undefined }) {
           </li>
 
           <li>
-            <Link href="/wallet">
+            <Link href={`wallet/${userId}`}>
               <PointIcon />
             </Link>
           </li>

--- a/vanx-app/hooks/usePosts.ts
+++ b/vanx-app/hooks/usePosts.ts
@@ -9,10 +9,18 @@ export const usePosts = () => {
       const response: PostIndexResponse = await PostIndex();
 
       if (response.success) {
-        setPosts(response.data.posts);
+        const postsData = response.data.posts.data;
+        const postsArray = Array.isArray(postsData) ? postsData : [];
+
+        console.log(postsData);
+        setPosts(postsArray);
+      } else {
+        console.log("API Response failed:", response);
+        setPosts([]);
       }
     } catch (error) {
       console.error("ERROR: ", error);
+      setPosts([]);
     }
   };
 

--- a/vanx-app/hooks/usePosts.ts
+++ b/vanx-app/hooks/usePosts.ts
@@ -1,88 +1,18 @@
-import { useState, useEffect } from 'react';
-import { Post, PostIndex } from '@/api/post/';
-
-export const mapApiPostToPost = (apiPost: any): Post => {
-  const userIcon = apiPost.user?.user_icon && apiPost.user.user_icon !== "default_icon.png"
-    ? `/uploads/user_icons/${apiPost.user.user_icon}`
-    : "/icons/default-user-icon.svg";
-  
-  const fileData = apiPost.postFiles || apiPost.postfile || apiPost.files || apiPost.post_files || apiPost.attachments || [];
-  
-  const files = fileData.map((file: any) => {
-    // バックエンドから post_file_url が返される場合はそのまま使用
-    // 返されない場合は post_file_path からフォールバック生成
-    const fileUrl = file.post_file_url || 
-      `${process.env.NEXT_PUBLIC_API_URL}/api/storage/${file.post_file_path || file.postFilePath || file.path}`;
-    
-    const filePath = file.post_file_path || file.postFilePath || file.path;
-    
-    return {
-      id: file.id.toString(),
-      url: fileUrl,
-      type: file.post_file_type || file.postFileType || file.type || "image",
-      name: filePath?.split('/').pop() || `file_${file.id}`
-    };
-  });
-
-  const mappedPost = {
-    id: apiPost.id,
-    userId: apiPost.user_id,
-    userName: apiPost.user?.name || "不明なユーザー",
-    imageSrc: userIcon,
-    contents: apiPost.post_content || "",
-    files: files,
-    postReactions: apiPost.post_reactions || []
-  };
-  
-  return mappedPost;
-};
+import { useState, useEffect } from "react";
+import { Post, PostIndex, PostIndexResponse } from "@/api/post/";
 
 export const usePosts = () => {
   const [posts, setPosts] = useState<Post[]>([]);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
 
   const fetchPosts = async () => {
     try {
-      setLoading(true);
-      setError(null);
-      
-      const response = await PostIndex();
+      const response: PostIndexResponse = await PostIndex();
 
-      if (response.success && "data" in response) {
-        const apiData = response.data as any;
-        let postsArray: any[] = [];
-        
-        if (Array.isArray(apiData.posts)) {
-          postsArray = apiData.posts;
-        } else if (apiData.posts && apiData.posts.data && Array.isArray(apiData.posts.data)) {
-          postsArray = apiData.posts.data;
-        } else {
-          setPosts([]);
-          return;
-        }
-        
-        if (postsArray.length === 0) {
-          //
-          // TODO: 投稿が0件の場合の表示（どうしよう🤔）
-          //
-          setPosts([]);
-          return;
-        }
-        
-        const mappedPosts: Post[] = postsArray.map((post: any) => {
-          return mapApiPostToPost(post);
-        });
-        setPosts(mappedPosts);
-      } else {
-        setError(response.message || "APIエラー");
-        console.error("APIエラー:", response.message);
+      if (response.success) {
+        setPosts(response.data.posts);
       }
     } catch (error) {
-      setError("例外エラーが発生しました");
-      console.error("例外エラー:", error);
-    } finally {
-      setLoading(false);
+      console.error("ERROR: ", error);
     }
   };
 
@@ -94,8 +24,5 @@ export const usePosts = () => {
     posts,
     setPosts,
     fetchPosts,
-    loading,
-    error,
-    mapApiPostToPost
   };
 };

--- a/vanx-app/hooks/usePosts.ts
+++ b/vanx-app/hooks/usePosts.ts
@@ -12,7 +12,6 @@ export const usePosts = () => {
         const postsData = response.data.posts.data;
         const postsArray = Array.isArray(postsData) ? postsData : [];
 
-        console.log(postsData);
         setPosts(postsArray);
       } else {
         console.log("API Response failed:", response);

--- a/vanx-app/package-lock.json
+++ b/vanx-app/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "autoprefixer": "^10.4.21",
         "axios": "^1.12.0",
+        "humps": "^2.0.1",
         "js-cookie": "^3.0.5",
         "next": "^15.3.4",
         "react": "^19.0.0",
@@ -17,6 +18,7 @@
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4.1.10",
+        "@types/humps": "^2.0.6",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -950,6 +952,13 @@
         "tailwindcss": "4.1.11"
       }
     },
+    "node_modules/@types/humps": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/humps/-/humps-2.0.6.tgz",
+      "integrity": "sha512-Fagm1/a/1J9gDKzGdtlPmmTN5eSw/aaTzHtj740oSfo+MODsSY2WglxMmhTdOglC8nxqUhGGQ+5HfVtBvxo3Kg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "20.19.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.1.tgz",
@@ -1449,6 +1458,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/humps": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/humps/-/humps-2.0.1.tgz",
+      "integrity": "sha512-E0eIbrFWUhwfXJmsbdjRQFQPrl5pTEoKlz163j1mTqqUnU9PgR4AgB8AIITzuB3vLBdxZXyZ9TDIrwB2OASz4g==",
+      "license": "MIT"
     },
     "node_modules/is-arrayish": {
       "version": "0.3.2",

--- a/vanx-app/package.json
+++ b/vanx-app/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "autoprefixer": "^10.4.21",
     "axios": "^1.12.0",
+    "humps": "^2.0.1",
     "js-cookie": "^3.0.5",
     "next": "^15.3.4",
     "react": "^19.0.0",
@@ -20,6 +21,7 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.10",
+    "@types/humps": "^2.0.6",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",


### PR DESCRIPTION
**【やったこと😁】**

- プロフィールページなどで`userId`を使ったルーティングを作成
- `postStore`、`postIndex`、`profilePostIndex`のrequestとresponseの型をバックエンドの実際のデータと合わせる
- `humps`のインストール
- `humps`を使って`postIndex`と`profilePostIndex`でデータを取得する際にcamelCaseに変換して受け取る
- `Post`型で`User`型を使用するよう修正
- `PostItem`に`user`が渡ってきた場合は`user.name`を、渡ってこなかった場合は`post.user.name`を表示するユーザー名に使用（`user`が渡ってくるのはプロフィールページのみ）
- `usePosts`内にあった、マッピングのための`mapApiPostToPost`を削除（`humps`を導入し不要になったため）

---

こんな感じ

<img width="316" height="633" alt="スクリーンショット 2025-10-07 10 34 09" src="https://github.com/user-attachments/assets/00469ad1-88a8-46cd-abdd-d4e2e72eda9a" />

